### PR TITLE
Improved S3 resource canonicalization

### DIFF
--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -627,7 +627,7 @@ class Query(BaseQuery):
                     part
                     for part
                     in query_parts
-                    if "=" not in part and part in subresources
+                    if part.split("=")[0] in subresources
                 )
                 if subs:
                     resource += "?" + "&".join(sorted(subs))

--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -608,15 +608,39 @@ class Query(BaseQuery):
         """
         Get an S3 resource path.
         """
+        # As <http://docs.amazonwebservices.com/AmazonS3/latest/dev/RESTAuthentication.html>
+        # says, if there is a subresource (e.g. ?acl), it is included, but other query
+        # parameters (e.g. ?prefix=... in a GET Bucket request) are not included.
+        # Yes, that makes no sense in terms of either security or consistency.
+        subresources = {
+            "acl", "lifecycle", "location", "logging", "notification",
+            "partNumber", "policy", "requestPayment", "torrent", "uploadId",
+            "uploads", "versionId", "versioning", "versions", "website",
+        }
+        resource = self.object_name
+        if resource:
+            parts = resource.split("?")
+            if len(parts) == 2:
+                resource, query = parts
+                query_parts = query.split("&")
+                subs = list(
+                    part
+                    for part
+                    in query_parts
+                    if "=" not in part and part in subresources
+                )
+                if subs:
+                    resource += "?" + "&".join(sorted(subs))
+
         path = "/"
         if self.bucket is not None:
             path += self.bucket
-        if self.bucket is not None and self.object_name:
-            if not self.object_name.startswith("/"):
+            if resource:
+                if not resource.startswith("/"):
+                    path += "/"
+                path += resource
+            elif not path.endswith("/"):
                 path += "/"
-            path += self.object_name
-        elif self.bucket is not None and not path.endswith("/"):
-            path += "/"
         return path
 
     def sign(self, headers):

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -1192,6 +1192,54 @@ class QueryTestCase(TXAWSTestCase):
         result = query.get_canonicalized_resource()
         self.assertEquals(result, "/images/advicedog.jpg")
 
+    def test_get_canonicalized_resource_with_subresource(self):
+        """
+        If a _subresource_ of the object is addressed via a query argument
+        at the end of the object name, the _subresource_ is included
+        in the canonical resource.
+        """
+        query = client.Query(
+            action="GET", bucket="images", object_name="advicedog.jpg?acl",
+        )
+        result = query.get_canonicalized_resource()
+        self.assertEquals(result, "/images/advicedog.jpg?acl")
+
+    def test_get_canonicalized_resource_with_other_query_args(self):
+        """
+        If there are query arguments on the object name which are not
+        subresources, they are not included in the canonical resource.
+        """
+        query = client.Query(
+            action="PUT", bucket="images",
+            object_name="advicedog.jpg?partNumber=3&uploadId=abc",
+        )
+        result = query.get_canonicalized_resource()
+        self.assertEquals(result, "/images/advicedog.jpg")
+
+    def test_get_canonicalized_resource_with_subresource_and_query_args(self):
+        """
+        If there is a subresource and other query arguments, only the
+        subresource is included in the canonical resource.
+        """
+        query = client.Query(
+            action="POST", bucket="images",
+            object_name="advicedog.jpg?restore&versionId=VersionID",
+        )
+        result = query.get_canonicalized_resource()
+        self.assertEquals(result, "/images/advicedog.jpg?restore")
+
+    def test_get_canonicalized_resource_with_query_args_and_subresource(self):
+        """
+        If there are query arguments and a subresource, only the
+        subresource is included in the canonical resource.
+        """
+        query = client.Query(
+            action="POST", bucket="images",
+            object_name="advicedog.jpg?versionId=VersionID&restore",
+        )
+        result = query.get_canonicalized_resource()
+        self.assertEquals(result, "/images/advicedog.jpg?restore")
+
     def test_sign(self):
         query = client.Query(action="PUT", creds=self.creds)
         signed = query.sign({})

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -1210,8 +1210,8 @@ class QueryTestCase(TXAWSTestCase):
         subresources, they are not included in the canonical resource.
         """
         query = client.Query(
-            action="PUT", bucket="images",
-            object_name="advicedog.jpg?partNumber=3&uploadId=abc",
+            action="GET", bucket="images",
+            object_name="advicedog.jpg?max-keys=50&marker=puppy",
         )
         result = query.get_canonicalized_resource()
         self.assertEquals(result, "/images/advicedog.jpg")
@@ -1222,11 +1222,11 @@ class QueryTestCase(TXAWSTestCase):
         subresource is included in the canonical resource.
         """
         query = client.Query(
-            action="POST", bucket="images",
-            object_name="advicedog.jpg?restore&versionId=VersionID",
+            action="GET", bucket="images",
+            object_name="advicedog.jpg?acl&max-keys=50",
         )
         result = query.get_canonicalized_resource()
-        self.assertEquals(result, "/images/advicedog.jpg?restore")
+        self.assertEquals(result, "/images/advicedog.jpg?acl")
 
     def test_get_canonicalized_resource_with_query_args_and_subresource(self):
         """
@@ -1235,10 +1235,22 @@ class QueryTestCase(TXAWSTestCase):
         """
         query = client.Query(
             action="POST", bucket="images",
-            object_name="advicedog.jpg?versionId=VersionID&restore",
+            object_name="advicedog.jpg?max-keys=50&acl",
         )
         result = query.get_canonicalized_resource()
-        self.assertEquals(result, "/images/advicedog.jpg?restore")
+        self.assertEquals(result, "/images/advicedog.jpg?acl")
+
+    def test_get_canonicalized_resource_with_subresources(self):
+        """
+        If there are multiple subresources, they are included in
+        lexicographical order.
+        """
+        query = client.Query(
+            action="POST", bucket="images",
+            object_name="advicedog.jpg?website&acl",
+        )
+        result = query.get_canonicalized_resource()
+        self.assertEquals(result, "/images/advicedog.jpg?acl&website")
 
     def test_sign(self):
         query = client.Query(action="PUT", creds=self.creds)

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -1204,6 +1204,18 @@ class QueryTestCase(TXAWSTestCase):
         result = query.get_canonicalized_resource()
         self.assertEquals(result, "/images/advicedog.jpg?acl")
 
+    def test_get_canonicalized_resource_with_subresource_with_value(self):
+        """
+        If a subresource of the object is addressed via a query argument
+        with a value at the end of the object name, the subresource
+        (including value) is included in the canonical resource.
+        """
+        query = client.Query(
+            action="GET", bucket="images", object_name="advicedog.jpg?versionId=7",
+        )
+        result = query.get_canonicalized_resource()
+        self.assertEquals(result, "/images/advicedog.jpg?versionId=7")
+
     def test_get_canonicalized_resource_with_other_query_args(self):
         """
         If there are query arguments on the object name which are not


### PR DESCRIPTION
S3's URLContext performed incomplete resource canonicalization according to the AWS docs.

This adds improved tests, particularly for subresource and query argument handling (and it makes them pass, of course).  I doubt this code is 100% correct even with these changes but it seems like a step in the right direction.
