### PR TITLE
Basic S3 get_bucket pagination primitives

### DIFF
--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -16,6 +16,7 @@ import mimetypes
 
 from twisted.web.http import datetimeToString
 
+from urllib import urlencode
 from dateutil.parser import parse as parseTime
 
 from txaws.client.base import BaseClient, BaseQuery, error_wrapper
@@ -129,15 +130,41 @@ class S3Client(BaseClient):
             bucket=bucket)
         return query.submit()
 
-    def get_bucket(self, bucket):
+    def get_bucket(self, bucket, marker=None, max_keys=None):
         """
         Get a list of all the objects in a bucket.
+
+        @param marker: If given, indicate a position in the overall
+            results where the results of this call should begin.  The
+            first result is the first object that sorts greater than
+            this marker.
+        @type marker: L{bytes} or L{NoneType}
+
+        @param max_keys: If given, the maximum number of objects to
+            return.
+        @type max_keys: L{int} or L{NoneType}
+
+        @return: A L{Deferred} that fires with a L{BucketListing}
+            describing the result.
+
+        @see: U{http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html}
         """
         query = self.query_factory(
             action="GET", creds=self.creds, endpoint=self.endpoint,
             bucket=bucket, receiver_factory=self.receiver_factory)
-        d = query.submit()
-        return d.addCallback(self._parse_get_bucket)
+        args = []
+        if marker is not None:
+            args.append(("marker", marker))
+        if max_keys is not None:
+            args.append(("max-keys", "%d" % (max_keys,)))
+        if args:
+            object_name = "?" + urlencode(args)
+        else:
+            object_name = None
+        url_context = URLContext(self.endpoint, bucket, object_name)
+        d = query.submit(url_context)
+        d.addCallback(self._parse_get_bucket)
+        return d
 
     def _parse_get_bucket(self, xml_bytes):
         root = XML(xml_bytes)

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -202,6 +202,24 @@ class S3ClientTestCase(TXAWSTestCase):
         d = s3.get_bucket("mybucket")
         return d.addCallback(check_results)
 
+    def test_get_bucket_pagination(self):
+        """
+        L{S3Client.get_bucket} accepts C{marker} and C{max_keys} arguments
+        to control pagination of results.
+        """
+        class StubQuery(client.Query):
+            def submit(query, url_context):
+                self.assertEqual(
+                    "http:///mybucket/?marker=abcdef&max-keys=42",
+                    url_context.get_url(),
+                )
+                return succeed(payload.sample_get_bucket_result)
+
+        creds = AWSCredentials("foo", "bar")
+        s3 = client.S3Client(creds, query_factory=StubQuery)
+        d = s3.get_bucket("mybucket", marker="abcdef", max_keys=42)
+        return d
+
     def test_get_bucket_location(self):
         """
         L{S3Client.get_bucket_location} creates a L{Query} to get a bucket's


### PR DESCRIPTION
This adds `marker` and `max_keys`  arguments to `S3Client.get_bucket`.  These control the number of results and where in the overall result set they begin (ie, they select a page of results).
