### PR TITLE
Avoid clobbering the AWS_* variables when running test_ssl.

### DIFF
--- a/txaws/client/tests/test_ssl.py
+++ b/txaws/client/tests/test_ssl.py
@@ -170,7 +170,6 @@ class CertsFilesTestCase(TXAWSTestCase):
         self.two_certs_dir = tempfile.mkdtemp()
         self.cert2 = self._write_pem(cert2, self.two_certs_dir, "cert2.pem")
         self.cert3 = self._write_pem(cert3, self.two_certs_dir, "cert3.pem")
-        self.environment_copy = os.environ.copy()
 
     def tearDown(self):
         super(CertsFilesTestCase, self).tearDown()
@@ -180,8 +179,6 @@ class CertsFilesTestCase(TXAWSTestCase):
         os.removedirs(self.no_certs_dir)
         os.removedirs(self.one_cert_dir)
         os.removedirs(self.two_certs_dir)
-        os.environ.clear()
-        os.environ.update(self.environment_copy)
 
     def _write_pem(self, cert, dir, filename):
         data = dump_certificate(FILETYPE_PEM, cert[1])

--- a/txaws/testing/base.py
+++ b/txaws/testing/base.py
@@ -13,14 +13,15 @@ class TXAWSTestCase(TestCase):
     def _stash_environ(self):
         self.orig_environ = dict(os.environ)
         self.addCleanup(self._restore_environ)
-        if "AWS_ACCESS_KEY_ID" in os.environ:
-            del os.environ["AWS_ACCESS_KEY_ID"]
-        if "AWS_SECRET_ACCESS_KEY" in os.environ:
-            del os.environ["AWS_SECRET_ACCESS_KEY"]
-        if "AWS_ENDPOINT" in os.environ:
-            del os.environ["AWS_ENDPOINT"]
+        to_delete = [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_ENDPOINT",
+        ]
+        for key in to_delete:
+            if key in os.environ:
+                del os.environ[key]
 
     def _restore_environ(self):
-        for key in set(os.environ) - set(self.orig_environ):
-            del os.environ[key]
+        os.environ.clear()
         os.environ.update(self.orig_environ)


### PR DESCRIPTION
This fixes test_ssl so it actually leaves AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID the same as it found them.  Previously the base class cleanup and the child class cleanup combined resulting in these being discarded.

This doesn't make any difference now but a future integration testing branch _may_ want to use these environment variables to specify how to access AWS.