### PR TITLE
Default to enabling hostname verification.

### DIFF
--- a/txaws/service.py
+++ b/txaws/service.py
@@ -26,7 +26,7 @@ class AWSServiceEndpoint(object):
         will be done when connecting to the endpoint.
     """
 
-    def __init__(self, uri="", method="GET", ssl_hostname_verification=False):
+    def __init__(self, uri="", method="GET", ssl_hostname_verification=True):
         self.host = ""
         self.port = None
         self.path = "/"


### PR DESCRIPTION
Release 0.2.3-based fix for #24 

The 0.2.3 release doesn't have any of our CI configuration and has various incompatibilities with the most recent release of Twisted (at least, in the test suite).  This makes it difficult to get a clean test run, let alone something public I can point at to demonstrate this is working.

The complexities of certificate verification and the sub-optimal interface to controlling this behavior (from txAWS's simple True/False to Twisted's old-style TLS context factories with few features and fewer nice knobs) make automated testing of the change challenging.  Further, since most of this code should be deleted and replaced with modern Twisted TLS context factory-using code, I'm not much inclined to spend a lot of effort making the code testable and then testing it automatically.

I *have* verified the consequences of this change against `get_page`.  See the description for the issue linked above.
