### PR TITLE
Improved s3 put object testing

### DIFF
--- a/txaws/_auth_v4.py
+++ b/txaws/_auth_v4.py
@@ -9,7 +9,6 @@ import urlparse
 
 import attr
 
-
 # The following four functions are taken straight from
 # http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
 def sign(key, msg):
@@ -221,10 +220,19 @@ class _CanonicalRequest(object):
             be signed.
         @type headers_to_sign: L{bytes}
 
-        @param payload_hash: The hex digest of the sha256 of the
-            request's payload.  Or C{None} for a request with an
-            unsigned body.
+        @param payload_hash: The hex digest of the sha256 hash of the
+            request's body.  If the body is empty, the hex digest of
+            the sha256 hash of the empty string.  If the payload hash
+            should not be included, C{None}.
         @type payload: L{bytes} or L{NoneType}
+
+        @return: A canonical request
+        @rtype: L{_CanonicalRequest}
+
+        @note: If C{payload_hash} is {None} then when the request is
+            submitted to AWS it must also include an
+            I{x-amz-content-sha256} header set to
+            C{b"UNSIGNED-PAYLOAD"}.
         """
         parsed = urlparse.urlparse(url)
         if payload_hash is None:
@@ -242,7 +250,6 @@ class _CanonicalRequest(object):
             signed_headers=_make_signed_headers(headers, headers_to_sign),
             payload_hash=payload_hash,
         )
-
 
     @classmethod
     def from_payload_and_headers(cls,

--- a/txaws/_auth_v4.py
+++ b/txaws/_auth_v4.py
@@ -222,10 +222,17 @@ class _CanonicalRequest(object):
         @type headers_to_sign: L{bytes}
 
         @param payload_hash: The hex digest of the sha256 of the
-            request's payload.
-        @type payload: L{bytes}
+            request's payload.  Or C{None} for a request with an
+            unsigned body.
+        @type payload: L{bytes} or L{NoneType}
         """
         parsed = urlparse.urlparse(url)
+        if payload_hash is None:
+            # This magic string tells AWS to disregard the payload for
+            # purposes of signing.  The x-amz-content-sha256 header
+            # sent to AWS in the request must have the exact same
+            # value for this to work.
+            payload_hash = b"UNSIGNED-PAYLOAD"
         return cls(
             method=method,
             canonical_uri=_make_canonical_uri(parsed),

--- a/txaws/_auth_v4.py
+++ b/txaws/_auth_v4.py
@@ -204,15 +204,9 @@ class _CanonicalRequest(object):
     payload_hash = attr.ib()
 
     @classmethod
-    def from_payload_and_headers(cls,
-                                 method,
-                                 url,
-                                 headers,
-                                 headers_to_sign,
-                                 payload):
+    def from_headers(cls, method, url, headers, headers_to_sign, payload_hash):
         """
-        Construct a L{_CanonicalRequest} from the provided headers and
-        payload.
+        Construct a L{_CanonicalRequest} from the provided headers.
 
         @param method: The HTTP method.
         @type method: L{bytes}
@@ -227,11 +221,9 @@ class _CanonicalRequest(object):
             be signed.
         @type headers_to_sign: L{bytes}
 
-        @param payload: The request's payload.
+        @param payload_hash: The hex digest of the sha256 of the
+            request's payload.
         @type payload: L{bytes}
-
-        @return: A canonical request
-        @rtype: L{_CanonicalRequest}
         """
         parsed = urlparse.urlparse(url)
         return cls(
@@ -241,8 +233,35 @@ class _CanonicalRequest(object):
             canonical_headers=_make_canonical_headers(headers,
                                                       headers_to_sign),
             signed_headers=_make_signed_headers(headers, headers_to_sign),
+            payload_hash=payload_hash,
+        )
+
+
+    @classmethod
+    def from_payload_and_headers(cls,
+                                 method,
+                                 url,
+                                 headers,
+                                 headers_to_sign,
+                                 payload):
+        """
+        Construct a L{_CanonicalRequest} from the provided headers and
+        payload.
+
+        @see: L{from_headers}
+
+        @param payload: The request's payload.
+        @type payload: L{bytes}
+
+        @return: A canonical request
+        @rtype: L{_CanonicalRequest}
+        """
+        return cls.from_headers(
+            method=method, url=url, headers=headers,
+            headers_to_sign=headers_to_sign,
             payload_hash=hashlib.sha256(payload).hexdigest(),
         )
+
 
     def serialize(self):
         """

--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -573,6 +573,11 @@ class Query(BaseQuery):
                  content_type=None, metadata={}, amz_headers={},
                  body_producer=None, *args, **kwargs):
         super(Query, self).__init__(*args, **kwargs)
+
+        # data might be None or "", alas.
+        if data and body_producer is not None:
+            raise ValueError("data and body_producer are mutually exclusive.")
+
         self.bucket = bucket
         self.object_name = object_name
         self.data = data

--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -628,7 +628,9 @@ class Query(BaseQuery):
         headers = {'x-amz-date': _auth_v4.makeAMZDate(instant)}
         if self.body_producer is None:
             data = self.data
-            headers["x-amz-content-sha256"] = hashlib.sha256(self.data).hexdigest()
+            if data is None:
+                data = b""
+            headers["x-amz-content-sha256"] = hashlib.sha256(data).hexdigest()
         else:
             data = None
             headers["x-amz-content-sha256"] = b"UNSIGNED-PAYLOAD"
@@ -691,9 +693,8 @@ class Query(BaseQuery):
         d = self.get_page(
             url_context.get_url(),
             method=self.action,
-            postdata=self.data,
+            postdata=self.data or b"",
             headers=self.get_headers(utcnow()),
-            body_producer=self.body_producer,
-            receiver_factory=self.receiver_factory)
+        )
 
         return d.addErrback(s3_error_wrapper)

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -1361,3 +1361,5 @@ class LiveS3TestCase(s3_integration_tests(get_live_client)):
     """
     Tests for the real S3 implementation against AWS itself.
     """
+    def test_put_object_body_producer(self):
+        self.skipTest("not yet implemented")

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -1361,5 +1361,3 @@ class LiveS3TestCase(s3_integration_tests(get_live_client)):
     """
     Tests for the real S3 implementation against AWS itself.
     """
-    def test_put_object_body_producer(self):
-        self.skipTest("not yet implemented")

--- a/txaws/testing/s3.py
+++ b/txaws/testing/s3.py
@@ -147,6 +147,7 @@ class _MemoryS3Client(object):
             )
             return finished
 
+        self._store_object(bucket, object_name, b"")
         return succeed(None)
 
 

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -116,6 +116,23 @@ def s3_integration_tests(get_client):
             )
 
         @inlineCallbacks
+        def test_put_object_empty(self):
+            """
+            C{put_object} creates an empty object if passed neither C{body}
+            nor C{body_producer}.
+            """
+            bucket_name = str(uuid4())
+            object_name = b"body_producer"
+
+            client = get_client(self)
+            yield client.create_bucket(bucket_name)
+            yield client.put_object(bucket_name, object_name)
+
+            retrieved = yield client.get_object(bucket_name, object_name)
+            self.assertEqual(b"", retrieved)
+
+
+        @inlineCallbacks
         def test_put_object_body_producer(self):
             """
             C{put_object} accepts a C{body_producer} argument which is an

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -4,10 +4,12 @@
 Integration tests for the S3 client(s).
 """
 
+from io import BytesIO
 from uuid import uuid4
 
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import inlineCallbacks, gatherResults
+from twisted.web.client import FileBodyProducer
 
 def s3_integration_tests(get_client):
     class S3IntegrationTests(TestCase):
@@ -98,6 +100,43 @@ def s3_integration_tests(get_client):
                 [], created,
                 "Expected to not find deleted objects in listing {}".format(objects),
             )
+
+        def test_put_object_errors(self):
+            """
+            C{put_object} raises L{ValueError} if called with two conflicting
+            sources of object body data.
+            """
+            client = get_client(self)
+            self.assertRaises(
+                ValueError,
+                client.put_object,
+                "bucket", "object",
+                # These two are mutually exclusive.
+                data="asd", body_producer=FileBodyProducer(BytesIO(b"def")),
+            )
+
+        @inlineCallbacks
+        def test_put_object_body_producer(self):
+            """
+            C{put_object} accepts a C{body_producer} argument which is an
+            L{IBodyProducer} which is used to provide the object's
+            content.
+            """
+            bucket_name = str(uuid4())
+            object_name = b"body_producer"
+            object_data = b"some random bytes"
+
+            client = get_client(self)
+
+            yield client.create_bucket(bucket_name)
+            yield client.put_object(
+                bucket_name,
+                object_name,
+                body_producer=FileBodyProducer(BytesIO(object_data)),
+            )
+
+            retrieved = yield client.get_object(bucket_name, object_name)
+            self.assertEqual(object_data, retrieved)
 
 
     return S3IntegrationTests

--- a/txaws/tests/test_auth_v4.py
+++ b/txaws/tests/test_auth_v4.py
@@ -401,6 +401,31 @@ class CanonicalRequestTestCase(unittest.SynchronousTestCase):
                          "273e3d9c0252e987180c1d05241ec5a7f8089b9c1652ccc09ccf"
                          "097d8cf33a4b")
 
+    def test_from_headers(self):
+        """
+        An instance is created from the given payload hash and headers.
+        """
+        url = 'https://www.amazon.com/blah?b=2&b=1&a=0'
+
+        canonical_request = _CanonicalRequest.from_headers(
+            method="POST",
+            url=url,
+            headers={b"header1": b"value1",
+                     b"header2": b"value2"},
+            headers_to_sign=(b"header1", b"header2"),
+            payload_hash=b"abcdef"
+        )
+        self.assertEqual(canonical_request.method, "POST")
+        self.assertEqual(canonical_request.canonical_uri,
+                         "https://www.amazon.com/blah")
+        self.assertEqual(canonical_request.canonical_query_string,
+                         "a=0&b=1&b=2")
+        self.assertEqual(canonical_request.canonical_headers,
+                         (b"header1:value1\n"
+                          b"header2:value2\n"))
+        self.assertEqual(canonical_request.signed_headers, "header1;header2")
+        self.assertEqual(canonical_request.payload_hash, b"abcdef")
+
     def test_from_payload_and_headers(self):
         """
         An instance is created from the given payload and headers.

--- a/txaws/tests/test_auth_v4.py
+++ b/txaws/tests/test_auth_v4.py
@@ -413,7 +413,7 @@ class CanonicalRequestTestCase(unittest.SynchronousTestCase):
             headers={b"header1": b"value1",
                      b"header2": b"value2"},
             headers_to_sign=(b"header1", b"header2"),
-            payload_hash=b"abcdef"
+            payload_hash=b"abcdef",
         )
         self.assertEqual(canonical_request.method, "POST")
         self.assertEqual(canonical_request.canonical_uri,
@@ -425,6 +425,33 @@ class CanonicalRequestTestCase(unittest.SynchronousTestCase):
                           b"header2:value2\n"))
         self.assertEqual(canonical_request.signed_headers, "header1;header2")
         self.assertEqual(canonical_request.payload_hash, b"abcdef")
+
+
+    def test_from_headers_unsigned_payload(self):
+        """
+        An instance is created with the magic "unsigned payload" string
+        and the given headers.
+        """
+        url = 'https://www.amazon.com/blah?b=2&b=1&a=0'
+
+        canonical_request = _CanonicalRequest.from_headers(
+            method="POST",
+            url=url,
+            headers={b"header1": b"value1",
+                     b"header2": b"value2"},
+            headers_to_sign=(b"header1", b"header2"),
+            payload_hash=None,
+        )
+        self.assertEqual(canonical_request.method, "POST")
+        self.assertEqual(canonical_request.canonical_uri,
+                         "https://www.amazon.com/blah")
+        self.assertEqual(canonical_request.canonical_query_string,
+                         "a=0&b=1&b=2")
+        self.assertEqual(canonical_request.canonical_headers,
+                         (b"header1:value1\n"
+                          b"header2:value2\n"))
+        self.assertEqual(canonical_request.signed_headers, "header1;header2")
+        self.assertEqual(canonical_request.payload_hash, b"UNSIGNED-PAYLOAD")
 
     def test_from_payload_and_headers(self):
         """


### PR DESCRIPTION
This adds an integration test for put_object that uses body_producer.  It also includes fixes for S3 test double and the real implementation to make the test pass.
