### PR TITLE
Depend on boto3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     extras_require={
-        "dev": ["zope.datetime"],
+        "dev": ["zope.datetime", "boto3"],
     },
     **extra_setup_args
     )


### PR DESCRIPTION
The integration test helpers need boto3 to work (fixes #31)