### PR TITLE
Add support for AWS shared credentials files.

### DIFF
--- a/txaws/newsfragments/52.feature
+++ b/txaws/newsfragments/52.feature
@@ -1,0 +1,1 @@
+txaws now supports reading the AWS_SHARED_CREDENTIALS_FILE and environment variable.

--- a/txaws/testing/base.py
+++ b/txaws/testing/base.py
@@ -24,6 +24,7 @@ class TXAWSTestCase(TestCase):
         to_delete = [
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
+            "AWS_SHARED_CREDENTIALS_FILE",
             "AWS_ENDPOINT",
         ]
         for key in to_delete:


### PR DESCRIPTION
Matches the order boto uses:

http://boto3.readthedocs.io/en/latest/guide/configuration.html