### PR TITLE
Remove TXAWSTestCase

### DIFF
--- a/txaws/client/discover/tests/test_command.py
+++ b/txaws/client/discover/tests/test_command.py
@@ -6,11 +6,11 @@
 from cStringIO import StringIO
 
 from twisted.internet.defer import succeed, fail
+from twisted.trial.unittest import TestCase
 from twisted.web.error import Error
 
 from txaws.client.discover.command import Command
 from txaws.ec2.client import Query
-from txaws.testing.base import TXAWSTestCase
 
 
 class FakeHTTPClient(object):
@@ -20,7 +20,7 @@ class FakeHTTPClient(object):
         self.url = url
 
 
-class CommandTestCase(TXAWSTestCase):
+class CommandTestCase(TestCase):
 
     def prepare_command(self, response, status, action, parameters={},
                         get_page=None, error=None):

--- a/txaws/client/discover/tests/test_entry_point.py
+++ b/txaws/client/discover/tests/test_entry_point.py
@@ -75,7 +75,7 @@ class ParseOptionsTestCase(TestCase):
         If the C{AWS_ACCESS_KEY_ID} environment variable is present, it will
         be used if the C{--key} command-line argument isn't specified.
         """
-        os.environ["AWS_ACCESS_KEY_ID"] = "key"
+        self.patch(os, "environ", {"AWS_ACCESS_KEY_ID": "key"})
         options = parse_options([
             "txaws-discover", "--secret", "secret", "--endpoint", "endpoint",
             "--action", "action"])
@@ -89,7 +89,7 @@ class ParseOptionsTestCase(TestCase):
         preferred over the value specified in the C{AWS_ACCESS_KEY_ID}
         environment variable.
         """
-        os.environ["AWS_ACCESS_KEY_ID"] = "fail"
+        self.patch(os, "environ", {"AWS_ACCESS_KEY_ID": "fail"})
         options = parse_options([
             "txaws-discover", "--key", "key", "--secret", "secret",
             "--endpoint", "endpoint", "--action", "action"])
@@ -102,7 +102,7 @@ class ParseOptionsTestCase(TestCase):
         If the C{AWS_SECRET_ACCESS_KEY} environment variable is present, it
         will be used if the C{--secret} command-line argument isn't specified.
         """
-        os.environ["AWS_SECRET_ACCESS_KEY"] = "secret"
+        self.patch(os, "environ", {"AWS_SECRET_ACCESS_KEY": "secret"})
         options = parse_options([
             "txaws-discover", "--key", "key", "--endpoint", "endpoint",
             "--action", "action"])
@@ -116,7 +116,7 @@ class ParseOptionsTestCase(TestCase):
         be preferred over the value specified in the C{AWS_SECRET_ACCESS_KEY}
         environment variable.
         """
-        os.environ["AWS_SECRET_ACCESS_KEY"] = "fail"
+        self.patch(os, "environ", {"AWS_SECRET_ACCESS_KEY": "fail"})
         options = parse_options([
             "txaws-discover", "--key", "key", "--secret", "secret",
             "--endpoint", "endpoint", "--action", "action"])
@@ -129,7 +129,7 @@ class ParseOptionsTestCase(TestCase):
         If the C{AWS_ENDPOINT} environment variable is present, it will be
         used if the C{--endpoint} command-line argument isn't specified.
         """
-        os.environ["AWS_ENDPOINT"] = "endpoint"
+        self.patch(os, "environ", {"AWS_ENDPOINT": "endpoint"})
         options = parse_options([
             "txaws-discover", "--key", "key", "--secret", "secret",
             "--action", "action"])
@@ -143,7 +143,7 @@ class ParseOptionsTestCase(TestCase):
         will be preferred over the value specified in the C{AWS_ENDPOINT}
         environment variable.
         """
-        os.environ["AWS_ENDPOINT"] = "fail"
+        self.patch(os, "environ", {"AWS_ENDPOINT": "fail"})
         options = parse_options([
             "txaws-discover", "--key", "key", "--secret", "secret",
             "--endpoint", "endpoint", "--action", "action"])

--- a/txaws/client/discover/tests/test_entry_point.py
+++ b/txaws/client/discover/tests/test_entry_point.py
@@ -7,12 +7,13 @@ from cStringIO import StringIO
 import os
 import sys
 
+from twisted.trial.unittest import TestCase
+
 from txaws.client.discover.entry_point import (
     OptionError, UsageError, get_command, main, parse_options, USAGE_MESSAGE)
-from txaws.testing.base import TXAWSTestCase
 
 
-class ParseOptionsTestCase(TXAWSTestCase):
+class ParseOptionsTestCase(TestCase):
 
     def test_parse_options(self):
         """
@@ -165,7 +166,7 @@ class ParseOptionsTestCase(TXAWSTestCase):
                            "--action", "action", "--help"])
 
 
-class GetCommandTestCase(TXAWSTestCase):
+class GetCommandTestCase(TestCase):
 
     def test_get_command_without_arguments(self):
         """An L{OptionError} is raised if no arguments are provided."""
@@ -223,7 +224,7 @@ class GetCommandTestCase(TXAWSTestCase):
         self.assertEqual({"Region.Name.0": "us-west-1"}, command.parameters)
 
 
-class MainTestCase(TXAWSTestCase):
+class MainTestCase(TestCase):
 
     def test_usage_message(self):
         """

--- a/txaws/client/ssl.py
+++ b/txaws/client/ssl.py
@@ -83,7 +83,7 @@ class VerifyingContextFactory(CertificateOptions):
         return context
 
 
-def get_ca_certs():
+def get_ca_certs(environ=os.environ):
     """
     Retrieve a list of CAs at either the DEFAULT_CERTS_PATH or the env
     override, TXAWS_CERTS_PATH.
@@ -96,7 +96,7 @@ def get_ca_certs():
     Note that both of these variables have have multiple paths in them, just
     like the familiar PATH environment variable (separated by colons).
     """
-    cert_paths = os.getenv("TXAWS_CERTS_PATH", DEFAULT_CERTS_PATH).split(":")
+    cert_paths = environ.get("TXAWS_CERTS_PATH", DEFAULT_CERTS_PATH).split(":")
     certificate_authority_map = {}
     for path in cert_paths:
         if not path:

--- a/txaws/client/tests/test_base.py
+++ b/txaws/client/tests/test_base.py
@@ -22,6 +22,7 @@ from twisted.python import log
 from twisted.python.filepath import FilePath
 from twisted.python.failure import Failure
 from twisted.test.test_sslverify import makeCertificate
+from twisted.trial.unittest import TestCase
 from twisted.web import server, static
 from twisted.web.http_headers import Headers
 from twisted.web.client import ResponseDone
@@ -38,11 +39,10 @@ from txaws.client.base import (
 )
 from txaws._auth_v4 import _CanonicalRequest
 from txaws.service import AWSServiceEndpoint
-from txaws.testing.base import TXAWSTestCase
 from txaws.testing.producers import StringBodyProducer
 
 
-class URLContextTests(TXAWSTestCase):
+class URLContextTests(TestCase):
     """
     Tests for L{txaws.client.base.url_context}.
     """
@@ -63,7 +63,7 @@ class URLContextTests(TXAWSTestCase):
         )
 
 
-class ErrorWrapperTestCase(TXAWSTestCase):
+class ErrorWrapperTestCase(TestCase):
 
     def test_204_no_content(self):
         failure = Failure(TwistedWebError(204, "No content"))
@@ -99,7 +99,7 @@ class ErrorWrapperTestCase(TXAWSTestCase):
         self.assertTrue(isinstance(error, ConnectionRefusedError))
 
 
-class BaseClientTestCase(TXAWSTestCase):
+class BaseClientTestCase(TestCase):
 
     def test_creation(self):
         client = BaseClient("creds", "endpoint", "query factory", "parser")
@@ -115,7 +115,7 @@ class PuttableResource(Resource):
         return ''
 
 
-class BaseQueryTestCase(TXAWSTestCase):
+class BaseQueryTestCase(TestCase):
 
     def setUp(self):
         self.cleanupServerConnections = 0
@@ -289,7 +289,7 @@ class BaseQueryTestCase(TXAWSTestCase):
         self.assertEqual(443, port)
 
 
-class StreamingBodyReceiverTestCase(TXAWSTestCase):
+class StreamingBodyReceiverTestCase(TestCase):
 
     def test_readback_mode_on(self):
         """
@@ -348,7 +348,7 @@ class StubAgent(object):
         return result
 
 
-class QueryTestCase(TXAWSTestCase):
+class QueryTestCase(TestCase):
     """
     Tests for L{query}.
     """

--- a/txaws/client/tests/test_ssl.py
+++ b/txaws/client/tests/test_ssl.py
@@ -11,6 +11,7 @@ from twisted.protocols.policies import WrappingFactory
 from twisted.python import log
 from twisted.python.filepath import FilePath
 from twisted.test.test_sslverify import makeCertificate
+from twisted.trial.unittest import TestCase
 from twisted.web import server, static
 
 try:
@@ -22,7 +23,6 @@ from txaws import exception
 from txaws.client import ssl
 from txaws.client.base import BaseQuery
 from txaws.service import AWSServiceEndpoint
-from txaws.testing.base import TXAWSTestCase
 
 
 def sibpath(path):
@@ -42,7 +42,7 @@ class WebDefaultOpenSSLContextFactory(DefaultOpenSSLContextFactory):
         return DefaultOpenSSLContextFactory.getContext(self)
 
 
-class BaseQuerySSLTestCase(TXAWSTestCase):
+class BaseQuerySSLTestCase(TestCase):
 
     def setUp(self):
         self.cleanupServerConnections = 0
@@ -153,7 +153,7 @@ class BaseQuerySSLTestCase(TXAWSTestCase):
             "subjectAltName not supported by older PyOpenSSL")
 
 
-class CertsFilesTestCase(TXAWSTestCase):
+class CertsFilesTestCase(TestCase):
 
     def setUp(self):
         super(CertsFilesTestCase, self).setUp()

--- a/txaws/client/tests/test_ssl.py
+++ b/txaws/client/tests/test_ssl.py
@@ -221,7 +221,7 @@ class CertsFilesTestCase(TestCase):
         certs = ssl.get_ca_certs(
             environ={
                 "TXAWS_CERTS_PATH": "%s:%s" % (
-                    self.no_certs, self.one_cert_dir,
+                    self.no_certs_dir, self.one_cert_dir,
                 ),
             },
         )

--- a/txaws/ec2/tests/test_client.py
+++ b/txaws/ec2/tests/test_client.py
@@ -9,11 +9,12 @@ import os
 from twisted.internet import reactor
 from twisted.internet.defer import succeed, fail
 from twisted.internet.error import ConnectionRefusedError
+from twisted.protocols.policies import WrappingFactory
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
+from twisted.trial.unittest import TestCase
 from twisted.web import server, static, util
 from twisted.web.error import Error as TwistedWebError
-from twisted.protocols.policies import WrappingFactory
 
 from txaws.util import iso8601time
 from txaws.credentials import AWSCredentials
@@ -23,11 +24,10 @@ from txaws.ec2.exception import EC2Error
 from txaws.exception import CredentialsNotFoundError
 from txaws.service import AWSServiceEndpoint, EC2_ENDPOINT_US
 from txaws.testing import payload
-from txaws.testing.base import TXAWSTestCase
 from txaws.testing.ec2 import FakePageGetter
 
 
-class ReservationTestCase(TXAWSTestCase):
+class ReservationTestCase(TestCase):
 
     def test_reservation_creation(self):
         reservation = model.Reservation(
@@ -37,7 +37,7 @@ class ReservationTestCase(TXAWSTestCase):
         self.assertEquals(reservation.groups, ["one", "two"])
 
 
-class InstanceTestCase(TXAWSTestCase):
+class InstanceTestCase(TestCase):
 
     def test_instance_creation(self):
         instance = model.Instance(
@@ -61,7 +61,7 @@ class InstanceTestCase(TXAWSTestCase):
         self.assertEquals(instance.ramdisk_id, "id4")
 
 
-class EC2ClientTestCase(TXAWSTestCase):
+class EC2ClientTestCase(TestCase):
 
     def test_init_no_creds(self):
         os.environ["AWS_SECRET_ACCESS_KEY"] = "foo"
@@ -162,7 +162,7 @@ class EC2ClientTestCase(TXAWSTestCase):
         return d
 
 
-class EC2ClientInstancesTestCase(TXAWSTestCase):
+class EC2ClientInstancesTestCase(TestCase):
 
     def check_parsed_instances(self, results):
         instance = results[0]
@@ -435,7 +435,7 @@ class EC2ClientInstancesTestCase(TXAWSTestCase):
         )
 
 
-class EC2ClientSecurityGroupsTestCase(TXAWSTestCase):
+class EC2ClientSecurityGroupsTestCase(TestCase):
 
     def test_describe_security_groups(self):
         """
@@ -1117,10 +1117,9 @@ class EC2ClientSecurityGroupsTestCase(TXAWSTestCase):
         return self.assertTrue(d)
 
 
-class EC2ClientEBSTestCase(TXAWSTestCase):
+class EC2ClientEBSTestCase(TestCase):
 
     def setUp(self):
-        TXAWSTestCase.setUp(self)
         self.creds = AWSCredentials("foo", "bar")
         self.endpoint = AWSServiceEndpoint(uri=EC2_ENDPOINT_US)
 
@@ -1625,10 +1624,7 @@ class EC2ClientEBSTestCase(TXAWSTestCase):
         return d
 
 
-class EC2ErrorWrapperTestCase(TXAWSTestCase):
-
-    def setUp(self):
-        TXAWSTestCase.setUp(self)
+class EC2ErrorWrapperTestCase(TestCase):
 
     def make_failure(self, status=None, type=None, message="", response=""):
         if not response:
@@ -1724,10 +1720,9 @@ class EC2ErrorWrapperTestCase(TXAWSTestCase):
         self.assertEquals(str(error), "400 Bad Request")
 
 
-class QueryTestCase(TXAWSTestCase):
+class QueryTestCase(TestCase):
 
     def setUp(self):
-        TXAWSTestCase.setUp(self)
         self.creds = AWSCredentials("foo", "bar")
         self.endpoint = AWSServiceEndpoint(uri=EC2_ENDPOINT_US)
 
@@ -1905,10 +1900,9 @@ class QueryTestCase(TXAWSTestCase):
         return d
 
 
-class SignatureTestCase(TXAWSTestCase):
+class SignatureTestCase(TestCase):
 
     def setUp(self):
-        TXAWSTestCase.setUp(self)
         self.creds = AWSCredentials("foo", "bar")
         self.endpoint = AWSServiceEndpoint(uri=EC2_ENDPOINT_US)
         self.params = {}
@@ -2006,10 +2000,9 @@ class SignatureTestCase(TXAWSTestCase):
             ], signature.sorted_params())
 
 
-class QueryPageGetterTestCase(TXAWSTestCase):
+class QueryPageGetterTestCase(TestCase):
 
     def setUp(self):
-        TXAWSTestCase.setUp(self)
         self.creds = AWSCredentials("foo", "bar")
         self.endpoint = AWSServiceEndpoint(uri=EC2_ENDPOINT_US)
         self.twisted_client_test_setup()
@@ -2059,10 +2052,9 @@ class QueryPageGetterTestCase(TXAWSTestCase):
         return deferred
 
 
-class EC2ClientAddressTestCase(TXAWSTestCase):
+class EC2ClientAddressTestCase(TestCase):
 
     def setUp(self):
-        TXAWSTestCase.setUp(self)
         self.creds = AWSCredentials("foo", "bar")
         self.endpoint = AWSServiceEndpoint(uri=EC2_ENDPOINT_US)
 
@@ -2195,7 +2187,7 @@ class EC2ClientAddressTestCase(TXAWSTestCase):
         return d
 
 
-class EC2ParserTestCase(TXAWSTestCase):
+class EC2ParserTestCase(TestCase):
 
     def setUp(self):
         self.parser = client.Parser()

--- a/txaws/ec2/tests/test_client.py
+++ b/txaws/ec2/tests/test_client.py
@@ -64,8 +64,12 @@ class InstanceTestCase(TestCase):
 class EC2ClientTestCase(TestCase):
 
     def test_init_no_creds(self):
-        os.environ["AWS_SECRET_ACCESS_KEY"] = "foo"
-        os.environ["AWS_ACCESS_KEY_ID"] = "bar"
+        self.patch(
+            os, "environ", {
+                "AWS_SECRET_ACCESS_KEY": "foo",
+                "AWS_ACCESS_KEY_ID": "bar",
+            },
+        )
         ec2 = client.EC2Client()
         self.assertNotEqual(None, ec2.creds)
 

--- a/txaws/ec2/tests/test_client.py
+++ b/txaws/ec2/tests/test_client.py
@@ -17,7 +17,7 @@ from twisted.web import server, static, util
 from twisted.web.error import Error as TwistedWebError
 
 from txaws.util import iso8601time
-from txaws.credentials import AWSCredentials
+from txaws.credentials import ENV_ACCESS_KEY, ENV_SECRET_KEY, AWSCredentials
 from txaws.ec2 import client
 from txaws.ec2 import model
 from txaws.ec2.exception import EC2Error
@@ -64,14 +64,13 @@ class InstanceTestCase(TestCase):
 class EC2ClientTestCase(TestCase):
 
     def test_init_no_creds(self):
-        self.patch(
-            os, "environ", {
-                "AWS_SECRET_ACCESS_KEY": "foo",
-                "AWS_ACCESS_KEY_ID": "bar",
-            },
-        )
+        self.addCleanup(os.environ.clear)
+        self.addCleanup(os.environ.update, os.environ.copy())
+        os.environ.clear()
+        os.environ.update([(ENV_ACCESS_KEY, "foo"), (ENV_SECRET_KEY, "bar")])
+
         ec2 = client.EC2Client()
-        self.assertNotEqual(None, ec2.creds)
+        self.assertIsNotNone(ec2.creds)
 
     def test_post_method(self):
         """

--- a/txaws/ec2/tests/test_model.py
+++ b/txaws/ec2/tests/test_model.py
@@ -1,11 +1,11 @@
 # Copyright (C) 2009 Canonical Ltd
 # Licenced under the txaws licence available at /LICENSE in the txaws source.
+from twisted.trial.unittest import TestCase
 
 from txaws.ec2 import model
-from txaws.testing.base import TXAWSTestCase
 
 
-class SecurityGroupTestCase(TXAWSTestCase):
+class SecurityGroupTestCase(TestCase):
 
     def test_creation_defaults(self):
         group = model.SecurityGroup("sg-a3f2", "name", "desc")
@@ -38,7 +38,7 @@ class SecurityGroupTestCase(TXAWSTestCase):
         self.assertEquals(group.allowed_ips[0].cidr_ip, "10.0.1.0/24")
 
 
-class UserIDGroupPairTestCase(TXAWSTestCase):
+class UserIDGroupPairTestCase(TestCase):
 
     def test_creation(self):
         user_id = "cowboy22"

--- a/txaws/route53/tests/test_model.py
+++ b/txaws/route53/tests/test_model.py
@@ -6,14 +6,15 @@ Tests for L{txaws.route53.model}.
 
 from ipaddress import IPv4Address
 
-from txaws.util import XML
-from txaws.testing.base import TXAWSTestCase
+from twisted.trial.unittest import TestCase
 
 from txaws.route53.model import (
     Name, SOA, NS, CNAME, A,
 )
+from txaws.util import XML
 
-class BasicResourceRecordTestCase(TXAWSTestCase):
+
+class BasicResourceRecordTestCase(TestCase):
     """
     Tests for L{IBasicResourceRecord} model objects.
     """

--- a/txaws/route53/tests/test_route53.py
+++ b/txaws/route53/tests/test_route53.py
@@ -6,13 +6,13 @@ Tests for ``txaws.route53``.
 
 from ipaddress import IPv4Address, IPv6Address
 
+from twisted.internet.task import Cooperator
+from twisted.trial.unittest import TestCase
 from twisted.web.static import Data
 from twisted.web.resource import IResource, Resource
-from twisted.internet.task import Cooperator
 
 from txaws.service import AWSServiceRegion
 from txaws.testing.integration import get_live_service
-from txaws.testing.base import TXAWSTestCase
 from txaws.testing.route53_tests import route53_integration_tests
 
 from txaws.route53.model import (
@@ -174,7 +174,7 @@ class sample_list_resource_records_with_alias_result(object):
 """.format(normal=normal_xml, alias=alias_xml).encode("utf-8")
 
 
-class ListHostedZonesTestCase(TXAWSTestCase):
+class ListHostedZonesTestCase(TestCase):
     """
     Tests for C{list_hosted_zones}.
     """
@@ -194,7 +194,7 @@ class ListHostedZonesTestCase(TXAWSTestCase):
         self.assertEquals(expected, zones)
 
 
-class ListResourceRecordSetsTestCase(TXAWSTestCase):
+class ListResourceRecordSetsTestCase(TestCase):
     """
     Tests for C{list_resource_record_sets}.
     """
@@ -499,7 +499,7 @@ class ListResourceRecordSetsTestCase(TXAWSTestCase):
 
 
 
-class ChangeResourceRecordSetsTestCase(TXAWSTestCase):
+class ChangeResourceRecordSetsTestCase(TestCase):
     """
     Tests for C{change_resource_record_sets}.
     """

--- a/txaws/route53/tests/test_util.py
+++ b/txaws/route53/tests/test_util.py
@@ -4,12 +4,12 @@
 Tests for L{txaws.route53._util}.
 """
 
-from txaws.testing.base import TXAWSTestCase
+from twisted.trial.unittest import TestCase
 
 from txaws.route53._util import maybe_bytes_to_unicode, to_xml, tags
 
 
-class MaybeBytesToUnicodeTestCase(TXAWSTestCase):
+class MaybeBytesToUnicodeTestCase(TestCase):
     """
     Tests for L{maybe_bytes_to_unicode}.
     """
@@ -38,7 +38,7 @@ class MaybeBytesToUnicodeTestCase(TXAWSTestCase):
         )
 
 
-class ToXMLTestCase(TXAWSTestCase):
+class ToXMLTestCase(TestCase):
     """
     Tests for L{to_xml}.
     """

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -1,13 +1,13 @@
 import datetime
 from hashlib import sha256
 import warnings
-from os import environ
 from urllib import quote
 
 from attr import assoc
 
-from twisted.web.http_headers import Headers
 from twisted.internet.defer import succeed
+from twisted.trial.unittest import TestCase
+from twisted.web.http_headers import Headers
 
 from txaws.credentials import AWSCredentials
 from txaws.client.base import RequestDetails
@@ -19,13 +19,14 @@ from txaws.testing.producers import StringBodyProducer
 from txaws.testing.s3_tests import s3_integration_tests
 from txaws.service import AWSServiceEndpoint, AWSServiceRegion, REGION_US_EAST_1
 from txaws.testing import payload
-from txaws.testing.base import TXAWSTestCase
 from txaws.testing.integration import get_live_service
 from txaws.util import calculate_md5
 
+
 EMPTY_CONTENT_SHA256 = sha256(b"").hexdigest().decode("ascii")
 
-class URLContextTestCase(TXAWSTestCase):
+
+class URLContextTestCase(TestCase):
 
     endpoint = AWSServiceEndpoint("https://s3.amazonaws.com/")
 
@@ -108,7 +109,8 @@ class URLContextTestCase(TXAWSTestCase):
         self.assertEquals(context.get_host(), b'0.0.0.0')
         self.assertEquals(context.get_url(), test_uri + b'foo/bar')
 
-class S3URLContextTestCase(TXAWSTestCase):
+
+class S3URLContextTestCase(TestCase):
     """
     Tests for L{s3_url_context}.
     """
@@ -159,10 +161,9 @@ def mock_query_factory(response_body):
     return MockQuery
 
 
-class S3ClientTestCase(TXAWSTestCase):
+class S3ClientTestCase(TestCase):
 
     def setUp(self):
-        TXAWSTestCase.setUp(self)
         self.endpoint = AWSServiceEndpoint()
 
     def test_list_buckets(self):
@@ -1125,7 +1126,7 @@ class S3ClientTestCase(TXAWSTestCase):
 
 
 
-class QueryTestCase(TXAWSTestCase):
+class QueryTestCase(TestCase):
 
     creds = AWSCredentials(access_key="fookeyid", secret_key="barsecretkey")
     endpoint = AWSServiceEndpoint("https://choopy.s3.amazonaws.com/")
@@ -1315,7 +1316,7 @@ class QueryTestCase(TXAWSTestCase):
 
 
 
-class MiscellaneousTestCase(TXAWSTestCase):
+class MiscellaneousTestCase(TestCase):
 
     def test_content_md5(self):
         self.assertEqual(calculate_md5("somedata"), "rvr3UC1SmUw7AZV2NqPN0g==")

--- a/txaws/testing/base.py
+++ b/txaws/testing/base.py
@@ -7,37 +7,9 @@ Basic functionality to aid in the definition of in-memory test doubles.
 import os
 from weakref import WeakKeyDictionary
 
-from twisted.trial.unittest import TestCase
 import attr
 
 import txaws.credentials
-
-
-class TXAWSTestCase(TestCase):
-    """Support for isolation of txaws tests."""
-
-    def setUp(self):
-        TestCase.setUp(self)
-        self._stash_environ()
-
-    def _stash_environ(self):
-        self.orig_environ = dict(os.environ)
-        self.addCleanup(self._restore_environ)
-        to_delete = [
-            txaws.credentials.ENV_ACCESS_KEY,
-            txaws.credentials.ENV_SECRET_KEY,
-            txaws.credentials.ENV_SHARED_CREDENTIALS_FILE,
-            "AWS_ENDPOINT",
-            txaws.credentials.ENV_PROFILE,
-        ]
-        for key in to_delete:
-            if key in os.environ:
-                del os.environ[key]
-
-    def _restore_environ(self):
-        os.environ.clear()
-        os.environ.update(self.orig_environ)
-
 
 
 class ControllerState(object):

--- a/txaws/tests/test_service.py
+++ b/txaws/tests/test_service.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2009 Duncan McGreggor <duncan@canonical.com>
 # Licenced under the txaws licence available at /LICENSE in the txaws source.
+from twisted.trial.unittest import TestCase
 
 from txaws.credentials import AWSCredentials
 from txaws.ec2.client import EC2Client
@@ -13,10 +14,9 @@ else:
 
 from txaws.service import (AWSServiceEndpoint, AWSServiceRegion,
                            EC2_ENDPOINT_EU, EC2_ENDPOINT_US, REGION_EU)
-from txaws.testing.base import TXAWSTestCase
 
 
-class AWSServiceEndpointTestCase(TXAWSTestCase):
+class AWSServiceEndpointTestCase(TestCase):
 
     def setUp(self):
         self.endpoint = AWSServiceEndpoint(uri="http://my.service/da_endpoint")
@@ -141,7 +141,7 @@ class AWSServiceEndpointTestCase(TXAWSTestCase):
         self.assertEquals(self.endpoint.method, "PUT")
 
 
-class AWSServiceRegionTestCase(TXAWSTestCase):
+class AWSServiceRegionTestCase(TestCase):
 
     def setUp(self):
         self.creds = AWSCredentials("foo", "bar")


### PR DESCRIPTION
After #56, no more need to have a test case that's patching the environ in and out.

First time I saw this I thought there were test bugs till I figured out that the superclass was removing the hard coded list of things.