### PR TITLE
Fix signing encoding handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-_trial_temp/
+*.egg-info/
 .testrepository
 .venv-*
+_trial_temp/

--- a/txaws/_auth_v4.py
+++ b/txaws/_auth_v4.py
@@ -284,7 +284,7 @@ class _CanonicalRequest(object):
             request.
         @rtype: L{str}
         """
-        return '\n'.join(attr.astuple(self))
+        return b'\n'.join(attr.astuple(self))
 
     def hash(self):
         """

--- a/txaws/client/base.py
+++ b/txaws/client/base.py
@@ -270,6 +270,14 @@ class _URLContext(object):
         )
 
 
+    def get_joined_path(self):
+        """
+        @return: The path component, un-urlencoded, but joined by slashes.
+        @rtype: L{bytes}
+        """
+        return b'/' + b'/'.join(seg.encode('utf-8') for seg in self.path)
+
+
     def get_encoded_query(self):
         """
         @return: The encoded query component.
@@ -412,7 +420,7 @@ class _Query(object):
         return _auth_v4._CanonicalRequest.from_request_components(
             method=self._details.method,
             url=(
-                self._details.url_context.get_encoded_path() +
+                self._details.url_context.get_joined_path() +
                 b"?" +
                 self._details.url_context.get_encoded_query()
             ),

--- a/txaws/client/base.py
+++ b/txaws/client/base.py
@@ -423,6 +423,8 @@ class _Query(object):
         return _auth_v4._CanonicalRequest.from_request_components(
             method=self._details.method,
             url=(
+                # We need to pass an unfortunate version of the path here: see
+                # https://github.com/twisted/txaws/issues/70
                 _get_joined_path(self._details.url_context) +
                 b"?" +
                 self._details.url_context.get_encoded_query()

--- a/txaws/client/base.py
+++ b/txaws/client/base.py
@@ -270,14 +270,6 @@ class _URLContext(object):
         )
 
 
-    def get_joined_path(self):
-        """
-        @return: The path component, un-urlencoded, but joined by slashes.
-        @rtype: L{bytes}
-        """
-        return b'/' + b'/'.join(seg.encode('utf-8') for seg in self.path)
-
-
     def get_encoded_query(self):
         """
         @return: The encoded query component.
@@ -304,6 +296,17 @@ class _URLContext(object):
             return b"%(scheme)s://%(host)s%(path)s%(query)s" % params
         params["port"] = self.port
         return b"%(scheme)s://%(host)s:%(port)d%(path)s%(query)s" % params
+
+
+def _get_joined_path(ctx):
+    """
+    @type ctx: L{_URLContext}
+    @param ctx: A URL context.
+
+    @return: The path component, un-urlencoded, but joined by slashes.
+    @rtype: L{bytes}
+    """
+    return b'/' + b'/'.join(seg.encode('utf-8') for seg in ctx.path)
 
 
 @attr.s
@@ -420,7 +423,7 @@ class _Query(object):
         return _auth_v4._CanonicalRequest.from_request_components(
             method=self._details.method,
             url=(
-                self._details.url_context.get_joined_path() +
+                _get_joined_path(self._details.url_context) +
                 b"?" +
                 self._details.url_context.get_encoded_query()
             ),

--- a/txaws/newsfragments/20.bugfix
+++ b/txaws/newsfragments/20.bugfix
@@ -1,0 +1,1 @@
+txaws now correctly signs requests with paths that require urlencoding.

--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -772,7 +772,7 @@ class Query(BaseQuery):
         if data is None:
             request = _auth_v4._CanonicalRequest.from_request_components(
                 method=method,
-                url=url_context.get_joined_path(),
+                url=url_context.get_encoded_path(),
                 headers=headers,
                 headers_to_sign=('host', 'x-amz-date'),
                 payload_hash=None,
@@ -780,7 +780,7 @@ class Query(BaseQuery):
         else:
             request = _auth_v4._CanonicalRequest.from_request_components_and_payload(
                 method=method,
-                url=url_context.get_joined_path(),
+                url=url_context.get_encoded_path(),
                 headers=headers,
                 headers_to_sign=('host', 'x-amz-date'),
                 payload=data,

--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -772,7 +772,7 @@ class Query(BaseQuery):
         if data is None:
             request = _auth_v4._CanonicalRequest.from_request_components(
                 method=method,
-                url=url_context.get_encoded_path(),
+                url=url_context.get_joined_path(),
                 headers=headers,
                 headers_to_sign=('host', 'x-amz-date'),
                 payload_hash=None,
@@ -780,7 +780,7 @@ class Query(BaseQuery):
         else:
             request = _auth_v4._CanonicalRequest.from_request_components_and_payload(
                 method=method,
-                url=url_context.get_encoded_path(),
+                url=url_context.get_joined_path(),
                 headers=headers,
                 headers_to_sign=('host', 'x-amz-date'),
                 payload=data,

--- a/txaws/testing/s3.py
+++ b/txaws/testing/s3.py
@@ -96,11 +96,11 @@ class _MemoryS3Client(MemoryClient):
             pieces = self._state.buckets[bucket]
         except KeyError:
             return fail(S3Error("<nosuchbucket/>", 400))
-        return pieces["listing"]
+        return succeed(pieces["listing"])
 
     @_rate_limited
     def get_bucket_location(self, bucket):
-        return b""
+        return succeed(b"")
 
     @_rate_limited
     def put_object(
@@ -144,11 +144,12 @@ class _MemoryS3Client(MemoryClient):
 
     def _store_object(self, bucket, obj, data):
         self._state.objects[bucket, obj] = data
+        return succeed(None)
 
 
     @_rate_limited
     def get_object(self, bucket, object_name):
-        return self._state.objects[bucket, object_name]
+        return succeed(self._state.objects[bucket, object_name])
 
     @_rate_limited
     def delete_object(self, bucket, object_name):
@@ -158,6 +159,7 @@ class _MemoryS3Client(MemoryClient):
             if item.key == object_name:
                 contents.remove(item)
                 break
+        return succeed(None)
 
 
 @attr.s

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -197,8 +197,11 @@ def s3_integration_tests(get_client):
                 yield client.put_object(
                     bucket_name, object_name, object_data,
                     content_type=object_type)
-                retrieved = yield client.get_object(bucket_name, object_name)
-                self.assertEqual(object_data, retrieved)
+            retrieved = yield gatherResults(
+                [client.get_object(bucket_name, object_name)
+                 for object_name in object_names],
+                consumeErrors=True)
+            self.assertEqual([object_data] * len(object_names), retrieved)
 
 
     return S3IntegrationTests

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -176,4 +176,29 @@ def s3_integration_tests(get_client):
             self.assertEqual(object_data, retrieved)
 
 
+        @inlineCallbacks
+        def test_object_encoded_chars(self):
+            """
+            C{get_object} and C{put_object} suceed with an object name that
+            requires encoding.
+            """
+            bucket_name = str(uuid4())
+            object_names = [
+                b'object:with:colons',
+                b'object with spaces',
+                u'\N{SNOWMAN}'.encode('utf-8'),
+                ]
+            object_data = b'some text'
+            object_type = b'application/x-txaws-integration-testing'
+
+            client = get_client(self)
+            yield client.create_bucket(bucket_name)
+            for object_name in object_names:
+                yield client.put_object(
+                    bucket_name, object_name, object_data,
+                    content_type=object_type)
+                retrieved = yield client.get_object(bucket_name, object_name)
+                self.assertEqual(object_data, retrieved)
+
+
     return S3IntegrationTests

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -179,7 +179,7 @@ def s3_integration_tests(get_client):
         @inlineCallbacks
         def test_object_encoded_chars(self):
             """
-            C{get_object} and C{put_object} suceed with an object name that
+            C{get_object} and C{put_object} succeed with an object name that
             requires encoding.
             """
             bucket_name = str(uuid4())


### PR DESCRIPTION
Fixes #20.

Note that while this fixes some cases that were broken in 0.2.3 as well as 0.3.0 (eg. `b'object with spaces'`), some of the cases were working in 0.2.3 and are now broken in 0.3.0 (eg. `b'object:with:colons'`), so this is a regression fix.