### PR TITLE
test_ssl_hostname_verification honors its docstring.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extra_setup_args = {}
 try:
     from setuptools import find_packages
     extra_setup_args['install_requires'] = [
-        'attrs', 'python-dateutil', 'twisted[tls]>=15.5.0,!=17.1.0', 'venusian', 'lxml',
+        'attrs', 'python-dateutil', 'twisted[tls]>=15.5.0', 'venusian', 'lxml',
         'incremental', 'pyrsistent', 'constantly',
     ]
 except ImportError:


### PR DESCRIPTION
It asserts that the created Agent received an instance of
twisted.internet.ssl.VerifyingContextFactory.  This fixes an issue
caused by Twisted 17.1.0 and later's use of HostnameEndpoint within
t.w.client.Agent.

This test should be deleted as part of the deprecation process
described in #47 (TLS support includes root certificate management
code that should be handled elsewhere).

Closes #72.