### PR TITLE
max_keys and marker support for get_bucket

### DIFF
--- a/txaws/newsfragments/87.feature
+++ b/txaws/newsfragments/87.feature
@@ -1,0 +1,1 @@
+txaws.s3.client.S3Client.get_bucket now accepts ``max_keys`` and ``marker`` parameters for controlling paging through objects.

--- a/txaws/newsfragments/87.feature
+++ b/txaws/newsfragments/87.feature
@@ -1,1 +1,1 @@
-txaws.s3.client.S3Client.get_bucket now accepts ``max_keys`` and ``marker`` parameters for controlling paging through objects.
+txaws.testing.s3.S3Client.get_bucket now accepts ``max_keys`` and ``marker`` parameters for controlling paging through objects.

--- a/txaws/s3/client.py
+++ b/txaws/s3/client.py
@@ -195,6 +195,9 @@ class S3Client(BaseClient):
         """
         Get a list of all the objects in a bucket.
 
+        @param bucket: The name of the bucket from which to retrieve objects.
+        @type bucket: L{unicode}
+
         @param marker: If given, indicate a position in the overall
             results where the results of this call should begin.  The
             first result is the first object that sorts greater than
@@ -426,7 +429,8 @@ class S3Client(BaseClient):
         An existing object with the same name will be replaced.
 
         @param bucket: The name of the bucket.
-        @param object: The name of the object.
+        @param object_name: The name of the object.
+        @type object_name: L{unicode}
         @param data: The data to write.
         @param content_type: The type of data being written.
         @param metadata: A C{dict} used to build C{x-amz-meta-*} headers.

--- a/txaws/s3/tests/test_client.py
+++ b/txaws/s3/tests/test_client.py
@@ -17,7 +17,7 @@ from txaws.s3.model import (RequestPayment, MultipartInitiationResponse,
                             MultipartCompletionResponse)
 from txaws.testing.producers import StringBodyProducer
 from txaws.testing.s3_tests import s3_integration_tests
-from txaws.service import AWSServiceEndpoint, AWSServiceRegion, REGION_US_EAST_1
+from txaws.service import AWSServiceEndpoint, REGION_US_EAST_1
 from txaws.testing import payload
 from txaws.testing.integration import get_live_service
 from txaws.util import calculate_md5

--- a/txaws/testing/s3.py
+++ b/txaws/testing/s3.py
@@ -116,7 +116,7 @@ class _MemoryS3Client(MemoryClient):
         prefixed_contents = (
             content
             for content
-            in listing.contents
+            in sorted(listing.contents, key=lambda item: item.key)
             if content.key.startswith(prefix)
             and content.key > keys_after
         )

--- a/txaws/testing/s3.py
+++ b/txaws/testing/s3.py
@@ -109,7 +109,7 @@ class _MemoryS3Client(MemoryClient):
             prefix = b""
 
         if marker is None:
-            keys_after = u""
+            keys_after = b""
         else:
             keys_after = marker
 

--- a/txaws/testing/s3.py
+++ b/txaws/testing/s3.py
@@ -83,7 +83,7 @@ class _MemoryS3Client(MemoryClient):
         assert bucket not in self._state.buckets
         self._state.buckets[bucket] = dict(
             bucket=Bucket(bucket, self._state.time()),
-            listing=BucketListing(bucket, None, None, None, False),
+            listing=BucketListing(bucket, None, None, None, u"false"),
         )
         return succeed(None)
 
@@ -109,16 +109,24 @@ class _MemoryS3Client(MemoryClient):
             prefix = b""
 
         contents = (
+        prefixed_contents = (
             content
             for content
             in listing.contents
             if content.key.startswith(prefix)
         )
 
+        contents = list(islice(prefixed_contents, max_keys))
+        is_truncated = u"false"
+        for ignored in prefixed_contents:
+            is_truncated = u"true"
+            break
+
         listing = attr.assoc(
             listing,
-            contents=list(islice(contents, max_keys)),
+            contents=contents,
             prefix=prefix,
+            is_truncated=is_truncated,
         )
         return succeed(listing)
 

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -247,7 +247,6 @@ def s3_integration_tests(get_client):
         # It takes some while to create the thousand-plus objects.  Give the
         # test some extra time.
         test_get_bucket_default_max_keys.timeout = 300
-        test_get_bucket_default_max_keys.skip = True
 
 
         def test_put_object_errors(self):

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -86,6 +86,8 @@ def s3_integration_tests(get_client):
                 1, len(created),
                 "Expected to find created object in listing {}".format(objects),
             )
+            self.assertEqual(objects.is_truncated, u"false")
+
             self.assertEqual(str(len(object_data)), created[0].size)
 
             data = yield client.get_object(bucket_name, object_name)
@@ -158,6 +160,7 @@ def s3_integration_tests(get_client):
             d.addCallback(put_objects)
             def got_objects(listing):
                 self.assertEqual(2, len(listing.contents))
+                self.assertEqual(listing.is_truncated, u"true")
             d.addCallback(got_objects)
             return d
 

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -110,7 +110,7 @@ def s3_integration_tests(get_client):
             The objects returned by C{get_bucket} are sorted lexicographically by their
             key.
             """
-            bucket_name = str(uuid4())
+            bucket_name = unicode(uuid4())
             client = get_client(self)
             d = client.create_bucket(bucket_name)
             def created_bucket(ignored):
@@ -137,7 +137,7 @@ def s3_integration_tests(get_client):
             A subset of S3 objects in a bucket can be retrieved by specifying a value
             for the ``prefix`` argument to ``get_bucket``.
             """
-            bucket_name = str(uuid4())
+            bucket_name = unicode(uuid4())
             client = get_client(self)
             yield client.create_bucket(bucket_name)
             yield client.put_object(bucket_name, b"a", b"foo")
@@ -152,7 +152,7 @@ def s3_integration_tests(get_client):
             C{get_bucket_location} returns a L{Deferred} that fires
             C{b""}.
             """
-            bucket_name = str(uuid4())
+            bucket_name = unicode(uuid4())
             client = get_client(self)
             d = client.create_bucket(bucket_name)
             def created_bucket(ignored):
@@ -171,7 +171,7 @@ def s3_integration_tests(get_client):
             C{max_keys} can be passed to C{get_bucket} to limit the number of
             results.
             """
-            bucket_name = str(uuid4())
+            bucket_name = unicode(uuid4())
             client = get_client(self)
             d = client.create_bucket(bucket_name)
             def created_bucket(ignored):
@@ -196,7 +196,7 @@ def s3_integration_tests(get_client):
             C{marker} can be passed to C{get_bucket} to specify the key in the result
             listing with which to start (the key after the value of C{marker}).
             """
-            bucket_name = str(uuid4())
+            bucket_name = unicode(uuid4())
             client = get_client(self)
             d = client.create_bucket(bucket_name)
             def created_bucket(ignored):
@@ -222,7 +222,7 @@ def s3_integration_tests(get_client):
             not specified.
             """
             max_keys = 1000
-            bucket_name = str(uuid4())
+            bucket_name = unicode(uuid4())
             client = get_client(self)
             d = client.create_bucket(bucket_name)
             def created_bucket(ignored):

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -206,9 +206,9 @@ def s3_integration_tests(get_client):
                     for i in range(3)
                 ))
             d.addCallback(created_bucket)
-            def put_objects(ignored):
+            def created_objects(ignored):
                 return client.get_bucket(bucket_name, marker=u"0")
-            d.addCallback(put_objects)
+            d.addCallback(created_objects)
             def got_objects(listing):
                 self.assertEqual(listing.marker, u"0")
                 self.assertEqual(u"1", listing.contents[0].key)

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -226,7 +226,7 @@ def s3_integration_tests(get_client):
             client = get_client(self)
             d = client.create_bucket(bucket_name)
             def created_bucket(ignored):
-                # Put a bunch ofobjects.  The default limit is 1000.
+                # Put a bunch of objects.  The default limit is 1000.
                 work = (
                     client.put_object(bucket_name, unicode(i).encode("ascii"))
                     for i in range(max_keys + 3)

--- a/txaws/testing/s3_tests.py
+++ b/txaws/testing/s3_tests.py
@@ -140,8 +140,8 @@ def s3_integration_tests(get_client):
             bucket_name = unicode(uuid4())
             client = get_client(self)
             yield client.create_bucket(bucket_name)
-            yield client.put_object(bucket_name, b"a", b"foo")
-            yield client.put_object(bucket_name, b"b", b"bar")
+            yield client.put_object(bucket_name, u"a", b"foo")
+            yield client.put_object(bucket_name, u"b", b"bar")
 
             objects = yield client.get_bucket(bucket_name, prefix=b"a")
             self.assertEqual([b"a"], list(obj.key for obj in objects.contents))
@@ -177,7 +177,7 @@ def s3_integration_tests(get_client):
             def created_bucket(ignored):
                 # Put a few objects in it so we can retrieve some of them.
                 return gatherResults(list(
-                    client.put_object(bucket_name, unicode(i).encode("ascii"))
+                    client.put_object(bucket_name, unicode(i))
                     for i in range(3)
                 ))
             d.addCallback(created_bucket)
@@ -202,7 +202,7 @@ def s3_integration_tests(get_client):
             def created_bucket(ignored):
                 # Put a few objects in it so we can retrieve some of them.
                 return gatherResults(list(
-                    client.put_object(bucket_name, unicode(i).encode("ascii"))
+                    client.put_object(bucket_name, unicode(i))
                     for i in range(3)
                 ))
             d.addCallback(created_bucket)


### PR DESCRIPTION
Fixes #87 

Note the issue only mentions max_keys but fixing is_truncated is pretty important once max_keys is supported so I did that as well.  And then I noticed marker was still unsupported so I couldn't resist implementing that as well.